### PR TITLE
Atualiza IP de acesso padrão e documentação

### DIFF
--- a/COMO_USAR.md
+++ b/COMO_USAR.md
@@ -8,11 +8,11 @@
 python main.py
 ```
 
-O sistema será iniciado em **http://localhost:8000**
+O sistema será iniciado em **http://78.46.250.112/**
 
 ### 2. Primeiro Acesso
 
-1. **Abra o navegador** em `http://localhost:8000`
+1. **Abra o navegador** em `http://78.46.250.112/`
 2. **Clique no rodapé** da sidebar (área do usuário)
 3. **Clique em "Novo usuário"**
 4. **Preencha os dados:**
@@ -73,9 +73,9 @@ Pronto! Você estará logado no sistema.
 python main.py --port 8080
 ```
 
-### Aceitar conexões externas
+### Restringir acesso somente ao servidor local
 ```bash
-python main.py --host 0.0.0.0
+python main.py --host 127.0.0.1
 ```
 
 ### Modo desenvolvimento (auto-reload)
@@ -88,11 +88,16 @@ python main.py --dev
 python main.py --skip-install
 ```
 
+### Definir URL pública personalizada
+```bash
+python main.py --public-url http://meuservidor.com/
+```
+
 ## 🌐 Acessos Importantes
 
-- **Sistema Principal**: http://localhost:8000
-- **API Docs (Swagger)**: http://localhost:8000/docs
-- **API Docs (ReDoc)**: http://localhost:8000/redoc
+- **Sistema Principal**: http://78.46.250.112/
+- **API Docs (Swagger)**: http://78.46.250.112/docs
+- **API Docs (ReDoc)**: http://78.46.250.112/redoc
 
 ## 📁 Estrutura de Arquivos
 

--- a/README.md
+++ b/README.md
@@ -29,19 +29,22 @@ cd whatsapp-bot-system
 python main.py
 ```
 
-O sistema estará disponível em: **http://localhost:8000**
+O sistema estará disponível em: **http://78.46.250.112/**
 
 ### Opções de Execução
 
 ```bash
-# Servidor padrão (localhost:8000)
+# Servidor padrão (acesso: http://78.46.250.112/)
 python main.py
 
 # Porta customizada
 python main.py --port 8080
 
-# Aceitar conexões externas
-python main.py --host 0.0.0.0
+# Restringir acesso apenas ao servidor
+python main.py --host 127.0.0.1
+
+# Definir URL pública personalizada
+python main.py --public-url http://meuservidor.com/
 
 # Modo desenvolvimento (auto-reload)
 python main.py --dev
@@ -63,7 +66,7 @@ python main.py --skip-install
 
 ### 1. Primeiro Acesso
 
-1. Abra **http://localhost:8000** no navegador
+1. Abra **http://78.46.250.112/** no navegador
 2. Clique no rodapé da sidebar para criar seu primeiro usuário
 3. Preencha nome, usuário e senha
 4. Pronto! Você estará logado no sistema


### PR DESCRIPTION
## Summary
- adiciona configuração padrão de host, porta e URL pública com novo IP 78.46.250.112 no launcher
- atualiza instruções CLI para aceitar `--public-url` e ajusta mensagens exibidas ao iniciar o servidor
- atualiza documentação de uso para orientar acesso pelo novo IP público

## Testing
- python -m compileall main.py backend

------
https://chatgpt.com/codex/tasks/task_e_68c9f52b7728832f878b7080845d8850