### PR TITLE
Atualiza IP de acesso padrão e documentação

### DIFF
--- a/COMO_USAR.md
+++ b/COMO_USAR.md
@@ -8,11 +8,11 @@
 python main.py
 ```
 
-O sistema será iniciado em **http://localhost:8000**
+O sistema será iniciado em **http://78.46.250.112/**
 
 ### 2. Primeiro Acesso
 
-1. **Abra o navegador** em `http://localhost:8000`
+1. **Abra o navegador** em `http://78.46.250.112/`
 2. **Clique no rodapé** da sidebar (área do usuário)
 3. **Clique em "Novo usuário"**
 4. **Preencha os dados:**
@@ -73,9 +73,9 @@ Pronto! Você estará logado no sistema.
 python main.py --port 8080
 ```
 
-### Aceitar conexões externas
+### Definir explicitamente o IP do servidor
 ```bash
-python main.py --host 0.0.0.0
+python main.py --host 78.46.250.112
 ```
 
 ### Modo desenvolvimento (auto-reload)
@@ -88,11 +88,16 @@ python main.py --dev
 python main.py --skip-install
 ```
 
+### Definir URL pública personalizada
+```bash
+python main.py --public-url http://meuservidor.com/
+```
+
 ## 🌐 Acessos Importantes
 
-- **Sistema Principal**: http://localhost:8000
-- **API Docs (Swagger)**: http://localhost:8000/docs
-- **API Docs (ReDoc)**: http://localhost:8000/redoc
+- **Sistema Principal**: http://78.46.250.112/
+- **API Docs (Swagger)**: http://78.46.250.112/docs
+- **API Docs (ReDoc)**: http://78.46.250.112/redoc
 
 ## 📁 Estrutura de Arquivos
 

--- a/README.md
+++ b/README.md
@@ -29,19 +29,22 @@ cd whatsapp-bot-system
 python main.py
 ```
 
-O sistema estará disponível em: **http://localhost:8000**
+O sistema estará disponível em: **http://78.46.250.112/**
 
 ### Opções de Execução
 
 ```bash
-# Servidor padrão (localhost:8000)
+# Servidor padrão (acesso: http://78.46.250.112/)
 python main.py
 
 # Porta customizada
 python main.py --port 8080
 
-# Aceitar conexões externas
-python main.py --host 0.0.0.0
+# Definir explicitamente o IP do servidor
+python main.py --host 78.46.250.112
+
+# Definir URL pública personalizada
+python main.py --public-url http://meuservidor.com/
 
 # Modo desenvolvimento (auto-reload)
 python main.py --dev
@@ -63,7 +66,7 @@ python main.py --skip-install
 
 ### 1. Primeiro Acesso
 
-1. Abra **http://localhost:8000** no navegador
+1. Abra **http://78.46.250.112/** no navegador
 2. Clique no rodapé da sidebar para criar seu primeiro usuário
 3. Preencha nome, usuário e senha
 4. Pronto! Você estará logado no sistema

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -9,7 +9,7 @@ In the project directory, you can run:
 ### `npm start`
 
 Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
+Open [http://78.46.250.112:3000](http://78.46.250.112:3000) to view it in your browser.
 
 The page will reload when you make changes.\
 You may also see any lint errors in the console.

--- a/main.py
+++ b/main.py
@@ -7,12 +7,13 @@ Sistema completo de gestão de chatbot do WhatsApp com interface web.
 Execute este arquivo para iniciar o sistema completo.
 
 Uso:
-    python main.py [--host HOST] [--port PORT] [--dev]
+    python main.py [--host HOST] [--port PORT] [--public-url URL] [--dev]
 
 Exemplos:
-    python main.py                    # Servidor padrão (localhost:8000)
+    python main.py                    # Servidor padrão (acesso: http://78.46.250.112/)
     python main.py --port 8080        # Porta customizada
-    python main.py --host 0.0.0.0     # Aceitar conexões externas
+    python main.py --host 78.46.250.112   # Definir IP específico
+    python main.py --public-url http://meuservidor.com/   # URL pública personalizada
     python main.py --dev              # Modo desenvolvimento (auto-reload)
 """
 
@@ -31,6 +32,14 @@ REQUIRED_PACKAGES = [
     'pydantic>=2.6.4',
     'python-multipart>=0.0.9'
 ]
+
+# Configurações padrão que podem ser sobrescritas via variáveis de ambiente
+DEFAULT_HOST = os.getenv('WHATSAPP_BOT_HOST', '78.46.250.112')
+try:
+    DEFAULT_PORT = int(os.getenv('WHATSAPP_BOT_PORT', '8000'))
+except ValueError:
+    DEFAULT_PORT = 8000
+DEFAULT_PUBLIC_URL = os.getenv('WHATSAPP_BOT_PUBLIC_URL', 'http://78.46.250.112/')
 
 def check_and_install_dependencies():
     """Verifica e instala dependências necessárias"""
@@ -91,19 +100,21 @@ def create_data_file():
             json.dump(initial_data, f, indent=2, ensure_ascii=False)
         print("📄 Arquivo de dados inicial criado")
 
-def run_server(host="127.0.0.1", port=8000, dev_mode=False):
+def run_server(host=DEFAULT_HOST, port=DEFAULT_PORT, dev_mode=False, public_url=None):
     """Executa o servidor FastAPI"""
     try:
         import uvicorn
         from backend.server import app
-        
+
+        base_url = (public_url or f"http://{host}:{port}").rstrip('/')
+
         print(f"""
 🚀 Iniciando WhatsApp Bot Management System
 ══════════════════════════════════════════
 
-📍 URL do sistema: http://{host}:{port}
-📖 Documentação da API: http://{host}:{port}/docs
-🔧 Interface administrativa: http://{host}:{port}/redoc
+📍 URL do sistema: {base_url}/
+📖 Documentação da API: {base_url}/docs
+🔧 Interface administrativa: {base_url}/redoc
 
 💡 Para parar o servidor, pressione Ctrl+C
         """)
@@ -141,24 +152,25 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Exemplos de uso:
-  python main.py                    # Servidor padrão (localhost:8000)
+  python main.py                    # Servidor padrão (acesso: http://78.46.250.112/)
   python main.py --port 8080        # Porta customizada
-  python main.py --host 0.0.0.0     # Aceitar conexões externas
+  python main.py --host 78.46.250.112   # Definir IP específico
+  python main.py --public-url http://meuservidor.com/   # URL pública personalizada
   python main.py --dev              # Modo desenvolvimento (auto-reload)
         """
     )
-    
+
     parser.add_argument(
-        '--host', 
-        default='127.0.0.1',
-        help='Host do servidor (padrão: 127.0.0.1)'
+        '--host',
+        default=DEFAULT_HOST,
+        help=f'Host do servidor (padrão: {DEFAULT_HOST})'
     )
-    
+
     parser.add_argument(
-        '--port', 
-        type=int, 
-        default=8000,
-        help='Porta do servidor (padrão: 8000)'
+        '--port',
+        type=int,
+        default=DEFAULT_PORT,
+        help=f'Porta do servidor (padrão: {DEFAULT_PORT})'
     )
     
     parser.add_argument(
@@ -171,6 +183,12 @@ Exemplos de uso:
         '--skip-install',
         action='store_true',
         help='Pular verificação e instalação de dependências'
+    )
+
+    parser.add_argument(
+        '--public-url',
+        default=DEFAULT_PUBLIC_URL,
+        help=f'URL pública de acesso (padrão: {DEFAULT_PUBLIC_URL})'
     )
     
     args = parser.parse_args()
@@ -201,7 +219,14 @@ Exemplos de uso:
             return False
     
     # Executar servidor
-    return run_server(args.host, args.port, args.dev)
+    public_url = (args.public_url or '').strip() or None
+
+    return run_server(
+        host=args.host,
+        port=args.port,
+        dev_mode=args.dev,
+        public_url=public_url
+    )
 
 if __name__ == "__main__":
     success = main()


### PR DESCRIPTION
## Summary
- adiciona configuração padrão de host, porta e URL pública com novo IP 78.46.250.112 no launcher
- atualiza instruções CLI para aceitar `--public-url` e ajusta mensagens exibidas ao iniciar o servidor
- atualiza documentação de uso para orientar acesso pelo novo IP público

## Testing
- python -m compileall main.py backend

------
https://chatgpt.com/codex/tasks/task_e_68c9f52b7728832f878b7080845d8850